### PR TITLE
Provide a constructor that takes generic istream objects; use it in the examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,16 +18,11 @@ int main(int argc, const char** argv) {
 		return -1;
 	}
 
-	// read entire image file
-	std::ifstream file(argv[1], std::ifstream::in|std::ifstream::binary);
-	file.seekg(0,std::ios::end);
-	std::streampos length = file.tellg();
-	file.seekg(0,std::ios::beg);
-	std::vector<uint8_t> data(length);
-	file.read((char*)data.data(), length);
+	// open a stream to read just the necessary parts of the image file
+	std::ifstream istream(argv[1], std::ifstream::binary);
 
 	// parse image EXIF and XMP metadata
-	TinyEXIF::EXIFInfo imageEXIF(data.data(), length);
+	TinyEXIF::EXIFInfo imageEXIF(istream);
 	if (imageEXIF.Fields)
 		std::cout
 			<< "Image Description " << imageEXIF.ImageDescription << "\n"

--- a/TinyEXIF.cpp
+++ b/TinyEXIF.cpp
@@ -853,8 +853,7 @@ int EXIFInfo::parseFrom(EXIFStream& stream) {
 }
 
 
-int EXIFInfo::parseFrom(std::istream& stream)
-{
+int EXIFInfo::parseFrom(std::istream& stream) {
 	class EXIFStdStream : public EXIFStream {
 	public:
 		EXIFStdStream(std::istream& stream)

--- a/TinyEXIF.cpp
+++ b/TinyEXIF.cpp
@@ -43,6 +43,7 @@
 #include <cfloat>
 #include <vector>
 #include <algorithm>
+#include <iostream>
 
 #ifdef _MSC_VER
 namespace {
@@ -877,7 +878,8 @@ int EXIFInfo::parseFrom(std::istream& stream)
 		std::istream& stream;
 		std::vector<uint8_t> buffer;
 	};
-	return parseFrom(EXIFStdStream(stream));
+	EXIFStdStream streamWrapper(stream);
+	return parseFrom(streamWrapper);
 }
 
 

--- a/TinyEXIF.h
+++ b/TinyEXIF.h
@@ -100,6 +100,7 @@ class TINYEXIF_LIB EXIFInfo {
 public:
 	EXIFInfo();
 	EXIFInfo(EXIFStream& stream);
+	EXIFInfo(std::istream& stream); // NB: the stream must have been opened in binary mode
 	EXIFInfo(const uint8_t* data, unsigned length);
 
 	// Parsing function for an entire JPEG image stream.
@@ -110,6 +111,7 @@ public:
 	// RETURN:  PARSE_SUCCESS (0) on success with 'result' filled out
 	//          error code otherwise, as defined by the PARSE_* macros
 	int parseFrom(EXIFStream& stream);
+	int parseFrom(std::istream& stream); // NB: the stream must have been opened in binary mode
 	int parseFrom(const uint8_t* data, unsigned length);
 
 	// Parsing function for an EXIF segment. This is used internally by parseFrom()

--- a/main.cpp
+++ b/main.cpp
@@ -9,27 +9,6 @@
 #include <vector>   // std::vector
 #include <iomanip>  // std::setprecision
 
-class EXIFStreamFile : public TinyEXIF::EXIFStream {
-public:
-	explicit EXIFStreamFile(const char* fileName)
-		: file(fileName, std::ifstream::in|std::ifstream::binary) {}
-	bool IsValid() const override {
-		return file.is_open();
-	}
-	const uint8_t* GetBuffer(unsigned desiredLength) override {
-		buffer.resize(desiredLength);
-		if (!file.read((char*)buffer.data(), desiredLength))
-			return NULL;
-		return buffer.data();
-	}
-	bool SkipBuffer(unsigned desiredLength) override {
-		return (bool)file.seekg(desiredLength,std::ios::cur);
-	}
-private:
-	std::ifstream file;
-	std::vector<uint8_t> buffer;
-};
-
 int main(int argc, const char** argv)
 {
 	if (argc != 2) {
@@ -37,9 +16,9 @@ int main(int argc, const char** argv)
 		return -1;
 	}
 
-	// read entire image file
-	EXIFStreamFile stream(argv[1]);
-	if (!stream.IsValid()) {
+	// open a stream to read just the necessary parts of the image file
+	std::ifstream stream(argv[1], std::ios::binary);
+	if (!stream) {
 		std::cout << "error: can not open '" << argv[1] << "'\n";
 		return -2;
 	}


### PR DESCRIPTION
Resolves #7 