### PR TITLE
Adding suppport of Google Camera motion photo metadata parsing

### DIFF
--- a/TinyEXIF.cpp
+++ b/TinyEXIF.cpp
@@ -1104,6 +1104,17 @@ int EXIFInfo::parseFromXMPSegmentXML(const char* szXML, unsigned len) {
 			}
 			return false;
 		}
+		// same as previous function but with unsigned int results
+		static bool Value(const tinyxml2::XMLElement* document, const char* name, uint32_t& value) {
+			const char* szAttribute = document->Attribute(name);
+			if (szAttribute == NULL) {
+				const tinyxml2::XMLElement* const element(document->FirstChildElement(name));
+				if (element == NULL || (szAttribute = element->GetText()) == NULL)
+					return false;
+			}
+			value = strtoul(szAttribute, NULL, 0); return true;
+			return false;
+		}
 	};
 	const char* szAbout(document->Attribute("rdf:about"));
 	if (0 == strcasecmp(Make.c_str(), "DJI") || (szAbout != NULL && 0 == strcasecmp(szAbout, "DJI Meta Data"))) {
@@ -1140,6 +1151,14 @@ int EXIFInfo::parseFromXMPSegmentXML(const char* szXML, unsigned len) {
 	}
 	ParseXMP::Value(document, "GPano:PosePitchDegrees", GPano.PosePitchDegrees);
 	ParseXMP::Value(document, "GPano:PoseRollDegrees", GPano.PoseRollDegrees);
+
+	const char* attrMicro(document->Attribute("GCamera:MicroVideo"));
+	if (attrMicro)
+	{
+		ParseXMP::Value(document, "GCamera:MicroVideo", MicroVideo.HasMicroVideo);
+		ParseXMP::Value(document, "GCamera:MicroVideoVersion", MicroVideo.MicroVideoVersion);
+		ParseXMP::Value(document, "GCamera:MicroVideoOffset", MicroVideo.MicroVideoOffset);
+	}
 
 	return PARSE_SUCCESS;
 }
@@ -1290,6 +1309,11 @@ void EXIFInfo::clear() {
 	// GPano
 	GPano.PosePitchDegrees = DBL_MAX;
 	GPano.PoseRollDegrees = DBL_MAX;
+
+	// Video metadata
+	MicroVideo.HasMicroVideo = 0;
+	MicroVideo.MicroVideoVersion = 0;
+	MicroVideo.MicroVideoOffset = 0;
 }
 
 } // namespace TinyEXIF

--- a/TinyEXIF.cpp
+++ b/TinyEXIF.cpp
@@ -1152,14 +1152,12 @@ int EXIFInfo::parseFromXMPSegmentXML(const char* szXML, unsigned len) {
 	ParseXMP::Value(document, "GPano:PosePitchDegrees", GPano.PosePitchDegrees);
 	ParseXMP::Value(document, "GPano:PoseRollDegrees", GPano.PoseRollDegrees);
 
-	const char* attrMicro(document->Attribute("GCamera:MicroVideo"));
-	if (attrMicro)
-	{
+	// parse GCamera:MicroVideo
+	if (document->Attribute("GCamera:MicroVideo")) {
 		ParseXMP::Value(document, "GCamera:MicroVideo", MicroVideo.HasMicroVideo);
 		ParseXMP::Value(document, "GCamera:MicroVideoVersion", MicroVideo.MicroVideoVersion);
 		ParseXMP::Value(document, "GCamera:MicroVideoOffset", MicroVideo.MicroVideoOffset);
 	}
-
 	return PARSE_SUCCESS;
 }
 

--- a/TinyEXIF.h
+++ b/TinyEXIF.h
@@ -308,6 +308,13 @@ public:
 		bool hasPosePitchDegrees() const; // Return true if PosePitchDegrees is available
 		bool hasPoseRollDegrees() const; // Return true if PoseRollDegrees is available
 	} GPano;
+
+	struct MicroVideo_t                // Google camera video file in metadata
+	{
+		uint32_t HasMicroVideo;			// not zero if exists
+		uint32_t MicroVideoVersion;		// just regularinfo
+		uint32_t MicroVideoOffset;		// offset from end of file
+	} MicroVideo;
 };
 
 } // namespace TinyEXIF

--- a/TinyEXIF.h
+++ b/TinyEXIF.h
@@ -308,12 +308,10 @@ public:
 		bool hasPosePitchDegrees() const; // Return true if PosePitchDegrees is available
 		bool hasPoseRollDegrees() const; // Return true if PoseRollDegrees is available
 	} GPano;
-
-	struct MicroVideo_t                // Google camera video file in metadata
-	{
-		uint32_t HasMicroVideo;			// not zero if exists
-		uint32_t MicroVideoVersion;		// just regularinfo
-		uint32_t MicroVideoOffset;		// offset from end of file
+	struct TINYEXIF_LIB MicroVideo_t {      // Google camera video file in metadata
+		uint32_t HasMicroVideo;         // not zero if exists
+		uint32_t MicroVideoVersion;     // just regularinfo
+		uint32_t MicroVideoOffset;      // offset from end of file
 	} MicroVideo;
 };
 


### PR DESCRIPTION
Android camera can create photos with video file in written in metadata.
So this fix can allow to get information about such video file in metadata.