### PR TITLE
Add support for big-endian CPUs

### DIFF
--- a/TinyEXIF.cpp
+++ b/TinyEXIF.cpp
@@ -95,9 +95,6 @@ namespace Tools {
 
 namespace TinyEXIF {
 
-uint32_t const _ONE32 = 1;
-bool const IS_LITTLE_ENDIAN = (reinterpret_cast<uint8_t const*>(&_ONE32))[0] == 1;
-
 enum JPEG_MARKERS {
 	JM_START = 0xFF,
 	JM_SOF0  = 0xC0,
@@ -946,6 +943,8 @@ int EXIFInfo::parseFromEXIFSegment(const uint8_t* buf, unsigned len) {
 	//  8 bytes
 	if (offs + 8 > len)
 		return PARSE_CORRUPT_DATA;
+	const uint32_t _ONE32 = 1;
+	const bool IS_LITTLE_ENDIAN = reinterpret_cast<uint8_t const*>(&_ONE32)[0] == 1;
 	bool alignIntel;
 	if (buf[offs] == 'I' && buf[offs+1] == 'I')
 		alignIntel = IS_LITTLE_ENDIAN; // 1: Intel byte alignment

--- a/TinyEXIF.cpp
+++ b/TinyEXIF.cpp
@@ -95,6 +95,9 @@ namespace Tools {
 
 namespace TinyEXIF {
 
+uint32_t const _ONE32 = 1;
+bool const IS_LITTLE_ENDIAN = (reinterpret_cast<uint8_t const*>(&_ONE32))[0] == 1;
+
 enum JPEG_MARKERS {
 	JM_START = 0xFF,
 	JM_SOF0  = 0xC0,
@@ -945,10 +948,10 @@ int EXIFInfo::parseFromEXIFSegment(const uint8_t* buf, unsigned len) {
 		return PARSE_CORRUPT_DATA;
 	bool alignIntel;
 	if (buf[offs] == 'I' && buf[offs+1] == 'I')
-		alignIntel = true; // 1: Intel byte alignment
+		alignIntel = IS_LITTLE_ENDIAN; // 1: Intel byte alignment
 	else
 	if (buf[offs] == 'M' && buf[offs+1] == 'M')
-		alignIntel = false; // 0: Motorola byte alignment
+		alignIntel = !IS_LITTLE_ENDIAN; // 0: Motorola byte alignment
 	else
 		return PARSE_UNKNOWN_BYTEALIGN;
 	EntryParser parser(buf, len, offs, alignIntel);


### PR DESCRIPTION
Added support for compiling / running on big-endian CPUs.

To solve this problem, I simply added a check if the current computer is little endian and inverted the results of `alignIntel` in case the CPU is big-endian.