### PR TITLE
TinyEXIF.h added inclusion of cstdint

### DIFF
--- a/TinyEXIF.h
+++ b/TinyEXIF.h
@@ -34,6 +34,7 @@
 #ifndef __TINYEXIF_H__
 #define __TINYEXIF_H__
 
+#include <cstdint>
 #include <string>
 #include <vector>
 


### PR DESCRIPTION
After the build of the library failed on one of my machine and the compiler suggested to include cstdint and I followed that suggestion, the build succeeded.