### PR TITLE
Fix integer overflow in parseString bounds check

### DIFF
--- a/TinyEXIF.cpp
+++ b/TinyEXIF.cpp
@@ -301,7 +301,7 @@ public:
 			if (value[num_components-1] == '\0')
 				value.resize(num_components-1);
 		} else
-		if (base+data+num_components <= len) {
+		if ((size_t)base+data+num_components <= len) {
 			const char* const sz((const char*)buf+base+data);
 			unsigned num(0);
 			while (num < num_components && sz[num] != '\0')

--- a/TinyEXIF.cpp
+++ b/TinyEXIF.cpp
@@ -301,7 +301,7 @@ public:
 			if (value[num_components-1] == '\0')
 				value.resize(num_components-1);
 		} else
-		if ((size_t)base+data+num_components <= len) {
+		if ((uint64_t)base+data+num_components <= (uint64_t)len) {
 			const char* const sz((const char*)buf+base+data);
 			unsigned num(0);
 			while (num < num_components && sz[num] != '\0')


### PR DESCRIPTION
Cast `base` to `size_t` in the parseString bounds check `base+data+num_components <= len` to prevent unsigned integer overflow.

When `data` is attacker-controlled (e.g. 0xffffffff), the 32-bit unsigned addition wraps around, causing the check to pass even though the computed offset is far beyond the buffer. This leads to an out-of-bounds heap read or segfault when dereferencing the resulting pointer.

Fixes #16